### PR TITLE
ensure dir exists first.

### DIFF
--- a/libs/fm.js
+++ b/libs/fm.js
@@ -31,6 +31,9 @@ var Fm = function(params) {
     this.love = path.join(this.home, 'love');
     this.shorthands = shorthands;
     this.isShowLrc = false;
+
+    // ensure dir exists
+    mkdirp.sync(this.love);
 };
 
 Fm.prototype.play = function(channel, user) {


### PR DESCRIPTION
Otherwise the first config will fails:

``` bash
$ douban.fm config
prompt: Douban Email:  fengmk2@gmail.com
prompt: Douban Password:  
{ [Error: ENOENT, open '/Users/mk2/douban.fm/.configs.json']
  errno: 34,
  code: 'ENOENT',
  path: '/Users/mk2/douban.fm/.configs.json' }
```
