### PR TITLE
install from faster registry and dist source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 ### 如何安装
 从 NPM 中安装稳定的版本
 ````
-$ [sudo] npm install douban.fm -g
+$ [sudo] npm install douban.fm -g --disturl=http://dist.u.qiniudn.com --registry=http://r.cnpmjs.org
 ````
+
 从 Git 仓库中安装最新的开发版本：
 ````
-$ [sudo] npm install git://github.com/turingou/douban.fm.git -g
+$ [sudo] npm install git://github.com/turingou/douban.fm.git -g --disturl=http://dist.u.qiniudn.com --registry=http://r.cnpmjs.org
 ````
 
 ### 模块依赖
@@ -28,14 +29,14 @@ $ [sudo] npm install git://github.com/turingou/douban.fm.git -g
 * 非 Mac OSX 用户需要检查 `node-speaker` 模块的外部依赖情况，详见 [node-speaker 文档](https://github.com/TooTallNate/node-speaker/#audio-backend-selection)，按照你使用的操作系统安装相应外部依赖
 * 确保权限一致。如果没有使用 sudo 则尝试使用 sudo 安装
 * 各种 linux 发行版外部依赖问题，先确认是否安装了 libasound2，如果没有，尝试 `sudo apt-get install libasound2-dev`，fedora 下 `yum install alsa-lib-devel`
- 
+
 #### windows
 
 * 最新版本的 *x86*  [Node.js for Windows](http://nodejs.org/download/),注意不要安装  *x64* 版本。
 * 安装 [Visual C++ 2010 Express](http://www.microsoft.com/visualstudio/eng/downloads#d-2010-express)。
 * 安装 [Python 2.7](http://www.python.org/download/), installed in the default location of `C:\Python27`。
 
-安装的时候都用默认的下一步吧,保险起见再重启一下电脑,现在,你的windows系统就可以安装带有c++ addons的Node.js 模块了。 
+安装的时候都用默认的下一步吧,保险起见再重启一下电脑,现在,你的windows系统就可以安装带有c++ addons的Node.js 模块了。
 
 如果遇到无法解决的问题，请到 [issue](https://github.com/turingou/douban.fm/issues) 板块先检索是否有人遇到相同的错误，或者直接发帖求助。
 
@@ -128,7 +129,7 @@ Fm.sdk.channel({
 ````
 $ git clone https://github.com/turingou/douban.fm.git
 $ cd douban.fm
-$ npm install
+$ npm install --disturl=http://dist.u.qiniudn.com --registry=http://r.cnpmjs.org
 $ npm test
 ````
 


### PR DESCRIPTION
看了一下issues, 很多用户是从npm第一次安装c++ 模块, 需要依赖node.tgz 源代码下载的时候出错,
直接从七牛的国内镜像下载, 能基本解决这个问题.
