### PR TITLE
修复登录豆瓣账户出现的403通信错误

### DIFF
--- a/libs/sdk.js
+++ b/libs/sdk.js
@@ -31,7 +31,8 @@ exports.auth = function(account, callback) {
       version: 100,
       email: account.email.toString(),
       password: account.password.toString()
-    }
+    },
+    headers: {'User-Agent': 'douban.fm'}
   }, function(err, result) {
     if (err) return callback(err);
     var result = result.body;


### PR DESCRIPTION
由于没有添加请求的User-Agent导致豆瓣服务器将请求禁止，所以添加上request的User-Agent以修复此问题
