### PR TITLE
fix无法读取 .douban.fm.history.json 的问题，但该文件现在依旧需手动创建

### DIFF
--- a/libs/fm.js
+++ b/libs/fm.js
@@ -151,7 +151,7 @@ Fm.prototype.play = function(channel, account) {
         var updates = {};
         updates[song.sid] = song;
         try {
-          fs.updateJSON(this.rc.history, updates);
+          fs.updateJSON(self.rc.history, updates);
         } catch (err) {
           // error must be logged in a private place.
         }


### PR DESCRIPTION
修复无法更新id3与无法播放本地歌曲的问题，但没有解决 .douban.fm.history.json 文件没有被自动创建的问题。
